### PR TITLE
3_ERC20_transferFrom_does_not_follow_spec

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -34,8 +34,7 @@ contract ERC20 is InterfaceERC20 {
         address _to,
         uint256 _value
     ) external override returns (bool) {
-        allowance[_from][msg.sender] -= _value;
-        emit Approval(_from, msg.sender, allowance[_from][msg.sender]);
+        _approve(_from, msg.sender, allowance[_from][msg.sender] - _value);
         _transfer(_from, _to, _value);
         return true;
     }

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -43,8 +43,7 @@ contract TestToken {
         address _to,
         uint256 _value
     ) external returns (bool) {
-        allowance[_from][msg.sender] -= _value;
-        emit Approval(_from, msg.sender, allowance[_from][msg.sender]);
+        _approve(_from, msg.sender, allowance[_from][msg.sender] - _value);
         _transfer(_from, _to, _value);
         return true;
     }


### PR DESCRIPTION
Not able to find any use case where transferFrom being called for any of these tokens. Need to verify again. If it is being relied upon, need to add appropriate approves there.

Signed-off-by: Aditya Gupta <adi.gupta13@gmail.com>